### PR TITLE
fix: Managed nodes attachment to load balancers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,12 @@ resource "aws_iam_policy" "policy" {
     "Condition": {"StringLike": {"autoscaling:ResourceTag/verta.ai/managed": "true"}}
   },
   {
+    "Sid": "AutoscalingArn",
+    "Effect": "Allow",
+    "Action": ["autoscaling:*"],
+    "Resource": "arn:aws:autoscaling:*:*:*:*:*/eks-verta-mgt-*"
+  },
+  {
     "Sid": "EC2all",
     "Effect": "Allow",
     "Action": [


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
We have encountered the following errors while using the current policy:
```
│ Error: Failure attaching AutoScaling Group eks-verta-mgt-eks-node-scribd-spot-user-managed-9ec2e626-557b-0e11-7c68-f331f7b85dd9 with ALB Target Group: arn:aws:elasticloadbalancing:us-east-2:559775055999:targetgroup/verta-mgt-eks-scribd/716576820fb933ac: AccessDenied: User: arn:aws:sts::559775055999:assumed-role/prod-scribdinternal-verta-ops/1674169850453874000 is not authorized to perform: autoscaling:AttachLoadBalancerTargetGroups on resource: arn:aws:autoscaling:us-east-2:559775055999:autoScalingGroup:1978151d-100a-42ba-a33e-d68a75dd9314:autoScalingGroupName/eks-verta-mgt-eks-node-scribd-spot-user-managed-9ec2e626-557b-0e11-7c68-f331f7b85dd9 because no identity-based policy allows the autoscaling:AttachLoadBalancerTargetGroups action
│ 	status code: 403, request id: f6659ed7-2db4-4426-a54d-6417ad43ee2b
│ 
│   with aws_autoscaling_attachment.alb_target_group,
│   on autoscaling_group.tf line 61, in resource "aws_autoscaling_attachment" "alb_target_group":
│   61: resource "aws_autoscaling_attachment" "alb_target_group" {
```

```
│ Error: Failure attaching AutoScaling Group eks-verta-mgt-eks-node-scribd-spot-svc-managed-08c2e627-a9eb-23cd-ff69-c6ad8a2f592f with ALB Target Group: arn:aws:elasticloadbalancing:us-east-2:559775055999:targetgroup/verta-mgt-eks-scribd/716576820fb933ac: AccessDenied: User: arn:aws:sts::559775055999:assumed-role/prod-scribdinternal-verta-ops/1674170026240311000 is not authorized to perform: autoscaling:AttachLoadBalancerTargetGroups on resource: arn:aws:autoscaling:us-east-2:559775055999:autoScalingGroup:04dbf1fc-74f4-42df-8cc8-ab6312689965:autoScalingGroupName/eks-verta-mgt-eks-node-scribd-spot-svc-managed-08c2e627-a9eb-23cd-ff69-c6ad8a2f592f because no identity-based policy allows the autoscaling:AttachLoadBalancerTargetGroups action
│ 	status code: 403, request id: 14124214-c3fa-45bf-bb4f-a91eaf4c96c9
│ 
│   with aws_autoscaling_attachment.alb_target_group,
│   on autoscaling_group.tf line 61, in resource "aws_autoscaling_attachment" "alb_target_group":
│   61: resource "aws_autoscaling_attachment" "alb_target_group" {
```

```
│ Error: Failure attaching AutoScaling Group eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 with ALB Target Group: arn:aws:elasticloadbalancing:us-east-2:559775055999:targetgroup/verta-mgt-eks-scribd/716576820fb933ac: AccessDenied: User: arn:aws:sts::559775055999:assumed-role/prod-scribdinternal-verta-ops/1674170249812624000 is not authorized to perform: autoscaling:AttachLoadBalancerTargetGroups on resource: arn:aws:autoscaling:us-east-2:559775055999:autoScalingGroup:b7eb438d-423b-4743-8ac8-3ef2afdc1332:autoScalingGroupName/eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 because no identity-based policy allows the autoscaling:AttachLoadBalancerTargetGroups action
│ 	status code: 403, request id: 46be0461-c7fe-4ec1-af51-a840c7db11f1
│ 
│   with aws_autoscaling_attachment.alb_target_group,
│   on autoscaling_group.tf line 61, in resource "aws_autoscaling_attachment" "alb_target_group":
│   61: resource "aws_autoscaling_attachment" "alb_target_group" {
│ 
╵
╷
│ Error: Failure attaching AutoScaling Group eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 with ALB Target Group: arn:aws:elasticloadbalancing:us-east-2:559775055999:targetgroup/verta-mgt-eks-pl-scribd-ssh/f5c9afd7167849a2: AccessDenied: User: arn:aws:sts::559775055999:assumed-role/prod-scribdinternal-verta-ops/1674170249812624000 is not authorized to perform: autoscaling:AttachLoadBalancerTargetGroups on resource: arn:aws:autoscaling:us-east-2:559775055999:autoScalingGroup:b7eb438d-423b-4743-8ac8-3ef2afdc1332:autoScalingGroupName/eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 because no identity-based policy allows the autoscaling:AttachLoadBalancerTargetGroups action
│ 	status code: 403, request id: 0dfa5183-729b-4b4a-82ec-c171b88e0184
│ 
│   with aws_autoscaling_attachment.pl_ssh_target_group,
│   on autoscaling_group.tf line 66, in resource "aws_autoscaling_attachment" "pl_ssh_target_group":
│   66: resource "aws_autoscaling_attachment" "pl_ssh_target_group" {
│ 
╵
╷
│ Error: Failure attaching AutoScaling Group eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 with ALB Target Group: arn:aws:elasticloadbalancing:us-east-2:559775055999:targetgroup/verta-mgt-eks-pl-scribd/80ae756eaa793123: AccessDenied: User: arn:aws:sts::559775055999:assumed-role/prod-scribdinternal-verta-ops/1674170249812624000 is not authorized to perform: autoscaling:AttachLoadBalancerTargetGroups on resource: arn:aws:autoscaling:us-east-2:559775055999:autoScalingGroup:b7eb438d-423b-4743-8ac8-3ef2afdc1332:autoScalingGroupName/eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 because no identity-based policy allows the autoscaling:AttachLoadBalancerTargetGroups action
│ 	status code: 403, request id: edc088f5-5e19-49a2-9e7c-a9be67345cb6
│ 
│   with aws_autoscaling_attachment.pl_core_target_group,
│   on autoscaling_group.tf line 71, in resource "aws_autoscaling_attachment" "pl_core_target_group":
│   71: resource "aws_autoscaling_attachment" "pl_core_target_group" {
│ 
╵
╷
│ Error: Failure attaching AutoScaling Group eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 with ALB Target Group: arn:aws:elasticloadbalancing:us-east-2:559775055999:targetgroup/verta-mgt-eks-pl-scribd-es/efaff7f861848abc: AccessDenied: User: arn:aws:sts::559775055999:assumed-role/prod-scribdinternal-verta-ops/1674170249812624000 is not authorized to perform: autoscaling:AttachLoadBalancerTargetGroups on resource: arn:aws:autoscaling:us-east-2:559775055999:autoScalingGroup:b7eb438d-423b-4743-8ac8-3ef2afdc1332:autoScalingGroupName/eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 because no identity-based policy allows the autoscaling:AttachLoadBalancerTargetGroups action
│ 	status code: 403, request id: 10c0341a-ea29-4b32-a95f-b204c7eb1109
│ 
│   with aws_autoscaling_attachment.pl_es_target_group,
│   on autoscaling_group.tf line 76, in resource "aws_autoscaling_attachment" "pl_es_target_group":
│   76: resource "aws_autoscaling_attachment" "pl_es_target_group" {
│ 
╵
╷
│ Error: Failure attaching AutoScaling Group eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 with ALB Target Group: arn:aws:elasticloadbalancing:us-east-2:559775055999:targetgroup/verta-mgt-eks-pl-scribd-es2/2f5133b5a49d3a2e: AccessDenied: User: arn:aws:sts::559775055999:assumed-role/prod-scribdinternal-verta-ops/1674170249812624000 is not authorized to perform: autoscaling:AttachLoadBalancerTargetGroups on resource: arn:aws:autoscaling:us-east-2:559775055999:autoScalingGroup:b7eb438d-423b-4743-8ac8-3ef2afdc1332:autoScalingGroupName/eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 because no identity-based policy allows the autoscaling:AttachLoadBalancerTargetGroups action
│ 	status code: 403, request id: 80d08fd7-1d38-497c-bc4f-3c711ad1bac2
│ 
│   with aws_autoscaling_attachment.pl_es_target_group2,
│   on autoscaling_group.tf line 81, in resource "aws_autoscaling_attachment" "pl_es_target_group2":
│   81: resource "aws_autoscaling_attachment" "pl_es_target_group2" {
│ 
╵
╷
│ Error: Failure attaching AutoScaling Group eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 with ALB Target Group: arn:aws:elasticloadbalancing:us-east-2:559775055999:targetgroup/verta-mgt-eks-pl-scribd-t/73a21cbf735e5015: AccessDenied: User: arn:aws:sts::559775055999:assumed-role/prod-scribdinternal-verta-ops/1674170249812624000 is not authorized to perform: autoscaling:AttachLoadBalancerTargetGroups on resource: arn:aws:autoscaling:us-east-2:559775055999:autoScalingGroup:b7eb438d-423b-4743-8ac8-3ef2afdc1332:autoScalingGroupName/eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 because no identity-based policy allows the autoscaling:AttachLoadBalancerTargetGroups action
│ 	status code: 403, request id: 103caadf-ecbc-4a2c-b897-bca0e6726bb1
│ 
│   with aws_autoscaling_attachment.pl_thanos_target_group,
│   on autoscaling_group.tf line 86, in resource "aws_autoscaling_attachment" "pl_thanos_target_group":
│   86: resource "aws_autoscaling_attachment" "pl_thanos_target_group" {
│ 
╵
╷
│ Error: Failure attaching AutoScaling Group eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 with ALB Target Group: arn:aws:elasticloadbalancing:us-east-2:559775055999:targetgroup/verta-mgt-eks-pl-scribd-t2/c0bea517991a6f51: AccessDenied: User: arn:aws:sts::559775055999:assumed-role/prod-scribdinternal-verta-ops/1674170249812624000 is not authorized to perform: autoscaling:AttachLoadBalancerTargetGroups on resource: arn:aws:autoscaling:us-east-2:559775055999:autoScalingGroup:b7eb438d-423b-4743-8ac8-3ef2afdc1332:autoScalingGroupName/eks-verta-mgt-eks-node-scribd-spot-infra-managed-64c2e629-5e8a-256f-93f1-d8b45394c049 because no identity-based policy allows the autoscaling:AttachLoadBalancerTargetGroups action
│ 	status code: 403, request id: a4a6e6aa-275e-4a4d-9ddb-ada4710adaa1
│ 
│   with aws_autoscaling_attachment.pl_thanos_target_group2,
│   on autoscaling_group.tf line 91, in resource "aws_autoscaling_attachment" "pl_thanos_target_group2":
│   91: resource "aws_autoscaling_attachment" "pl_thanos_target_group2" {
```

```
│ Error: Failure attaching AutoScaling Group eks-verta-mgt-eks-node-scribd-spot-infra-prometheus-managed-1ac2e62a-a015-343c-82d0-896297e096e5 with ALB Target Group: arn:aws:elasticloadbalancing:us-east-2:559775055999:targetgroup/verta-mgt-eks-scribd/716576820fb933ac: AccessDenied: User: arn:aws:sts::559775055999:assumed-role/prod-scribdinternal-verta-ops/1674170412979353000 is not authorized to perform: autoscaling:AttachLoadBalancerTargetGroups on resource: arn:aws:autoscaling:us-east-2:559775055999:autoScalingGroup:86ffd09c-0ebf-43d5-85ca-02d61e8219d6:autoScalingGroupName/eks-verta-mgt-eks-node-scribd-spot-infra-prometheus-managed-1ac2e62a-a015-343c-82d0-896297e096e5 because no identity-based policy allows the autoscaling:AttachLoadBalancerTargetGroups action
│ 	status code: 403, request id: 247abb78-61a1-4342-bec8-df470dd99363
│ 
│   with aws_autoscaling_attachment.alb_target_group,
│   on autoscaling_group.tf line 62, in resource "aws_autoscaling_attachment" "alb_target_group":
│   62: resource "aws_autoscaling_attachment" "alb_target_group" {
```

This happens because we have less control over managed nodes names. However, we can control them by name pattern.
